### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build, Check and Test
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/makiftutuncu/tapik/security/code-scanning/2](https://github.com/makiftutuncu/tapik/security/code-scanning/2)

To fix this issue, you should add a `permissions` block to your workflow that restricts the default `GITHUB_TOKEN` permissions. The safest and recommended starting point for most CI workflows that do not require write access is `contents: read`. This permission allows the workflow to check out code, but disallows changes to repository contents or other write operations. It is sufficient for reading code and running tests. Add the `permissions` block at the root of your workflow file (above `jobs:`) to ensure it applies to all jobs not defining their own permissions. Edit `.github/workflows/build.yml`, inserting the block after the workflow name and before the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
