### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,4 +1,6 @@
 name: Preview Documentation Website
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/makiftutuncu/tapik/security/code-scanning/1](https://github.com/makiftutuncu/tapik/security/code-scanning/1)

To fix the issue, introduce an explicit `permissions:` block restricting GITHUB_TOKEN scopes as narrowly as possible. This is best done at the workflow (top) level unless a finer adjustment is needed for individual jobs. Since this workflow only checks out code and uploads artifacts, it only needs `contents: read` permission. Add:

```yaml
permissions:
  contents: read
```

immediately after the workflow `name:` declaration (before `on:`), as shown in the documentation and examples. No additional changes, imports, or job-level overrides are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
