### PR TITLE
Fix Mermaid diagram rendering in documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,11 @@ markdown_extensions:
   - footnotes
   - attr_list
   - md_in_html
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
 
 nav:
   - Home: index.md


### PR DESCRIPTION
This PR fixes issue #60 by adding the pymdownx.superfences extension with Mermaid support to mkdocs.yml.
## Changes
- Added pymdownx.superfences to markdown_extensions
- Configured custom_fences for mermaid diagrams
## Testing
- Verified locally with mkdocs serve that Mermaid diagrams now render correctly
Closes #60