### PR TITLE
Fix Gradle Plugin publication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+.venv

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -213,12 +213,6 @@ tasks.withType<PublishToMavenRepository>().configureEach {
     dependsOn(tasks.withType<Sign>())
 }
 
-tasks.withType<AbstractPublishToMaven>().configureEach {
-    onlyIf("Skip redundant pluginMaven publication created by kotlin-dsl") {
-        !name.contains("PluginMavenPublication", ignoreCase = true)
-    }
-}
-
 val publishingToMavenLocal =
     gradle.startParameter.taskNames.any { it.contains("ToMavenLocal") }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    `kotlin-dsl`
+    id("org.jetbrains.kotlin.jvm")
     id("buildlogic.convention.kotlin-dsl")
     `java-gradle-plugin`
     `maven-publish`

--- a/gradle-plugin/src/main/kotlin/gradle/TapikGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/gradle/TapikGradlePlugin.kt
@@ -2,7 +2,6 @@ package dev.akif.tapik.plugin.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.register
 
 /**
  * Registers Tapik-specific Gradle tasks and DSL extensions for client generation.
@@ -18,25 +17,25 @@ class TapikGradlePlugin : Plugin<Project> {
 
         val generatedSources = target.layout.buildDirectory.dir("generated/sources/tapik/main/kotlin")
 
-        val tapikGenerate = target.tasks.register<TapikGenerateTask>("tapikGenerate") {
-            group = "tapik"
-            description = "Generates Tapik outputs"
-            endpointPackages.set(target.provider { extension.resolvedEndpointPackages() })
-            outputDirectory.set(target.layout.buildDirectory.dir("generated"))
-            sourceDirectory.set(target.layout.projectDirectory.dir("src/main/kotlin"))
-            compiledClassesDirectory.set(target.layout.buildDirectory.dir("classes/kotlin/main"))
-            generatedSourcesDirectory.set(generatedSources)
-            additionalClassDirectories.set(collectClassDirectories(target))
-            runtimeClasspath.from(target.configurations.getByName("runtimeClasspath"))
-            enabledGeneratorIds.set(target.provider { extension.configuredGeneratorIds() })
+        val tapikGenerate = target.tasks.register("tapikGenerate", TapikGenerateTask::class.java) {
+            it.group = "tapik"
+            it.description = "Generates Tapik outputs"
+            it.endpointPackages.set(target.provider { extension.resolvedEndpointPackages() })
+            it.outputDirectory.set(target.layout.buildDirectory.dir("generated"))
+            it.sourceDirectory.set(target.layout.projectDirectory.dir("src/main/kotlin"))
+            it.compiledClassesDirectory.set(target.layout.buildDirectory.dir("classes/kotlin/main"))
+            it.generatedSourcesDirectory.set(generatedSources)
+            it.additionalClassDirectories.set(collectClassDirectories(target))
+            it.runtimeClasspath.from(target.configurations.getByName("runtimeClasspath"))
+            it.enabledGeneratorIds.set(target.provider { extension.configuredGeneratorIds() })
         }
 
         tapikGenerate.configure {
             val upstreamClasses = target.rootProject.subprojects
                 .filter { it != target }
                 .mapNotNull { it.tasks.findByName("classes") }
-            dependsOn(upstreamClasses)
-            dependsOn(target.tasks.named("classes"))
+            it.dependsOn(upstreamClasses)
+            it.dependsOn(target.tasks.named("classes"))
         }
 
         target.plugins.withId("org.jetbrains.kotlin.jvm") {


### PR DESCRIPTION
Fixes an issue where the actual gradle-plugin artifact was not being published to Maven Central.

- Remove kotlin-dsl plugin from gradle-plugin module to avoid conflicts

- Add org.jetbrains.kotlin.jvm plugin for compilation

- Refactor TapikGradlePlugin to remove Kotlin DSL dependencies

- Remove aggressive publication filtering from root build